### PR TITLE
Updates for esmini 2.X

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,17 @@
-FROM thewtex/opengl:ubuntu1604
+FROM thewtex/opengl:ubuntu1804
 
 WORKDIR ~/
 
-RUN apt-get -yqq update && apt-get -yq install build-essential git pkg-config libgl1-mesa-dev libpthread-stubs0-dev libjpeg-dev libxml2-dev libpng12-dev libtiff5-dev libgdal-dev libpoppler-dev libdcmtk-dev libjasper-dev libgstreamer1.0-dev libgtk2.0-dev libcairo2-dev libpoppler-glib-dev libxrandr-dev libxinerama-dev curl wget libav-tools mkvtoolnix xvfb && apt-get autoremove -y && apt-get clean -y
+RUN apt-get -yqq update && apt-get -yq install build-essential git pkg-config libgl1-mesa-dev libpthread-stubs0-dev libjpeg-dev libxml2-dev libpng-dev libtiff5-dev libgdal-dev libpoppler-dev libdcmtk-dev libgstreamer1.0-dev libgtk2.0-dev libcairo2-dev libpoppler-glib-dev libxrandr-dev libxinerama-dev curl cmake wget ffmpeg mkvtoolnix xvfb unzip && apt-get autoremove -y && apt-get clean -y
 
-RUN version=3.15 && \
-build=3 && \
-mkdir ~/temp && \
-cd ~/temp && \
-wget https://cmake.org/files/v$version/cmake-$version.$build.tar.gz && \
-tar -xzvf cmake-$version.$build.tar.gz && \
-cd cmake-$version.$build/ && \
-./bootstrap && \
-make -j4 && \
-make install
+RUN curl -L -o esmini.zip https://github.com/esmini/esmini/releases/latest/download/esmini-bin_ubuntu.zip && \
+unzip esmini.zip -d /root/esmini
 
-RUN cd ~/ && \
-git clone https://github.com/openscenegraph/OpenSceneGraph && \
-cd OpenSceneGraph && \
-git checkout OpenSceneGraph-3.6.3 && \
-mkdir build && \
-cd build && \
-cmake ../ && \
-make -j4 && \
-make install && \
-ldconfig
-
-RUN cd ~/ && \
-git clone https://github.com/esmini/esmini && \
-cd esmini && \
-mkdir -p externals/OpenSceneGraph/v10/build && \
-OSG_PATH=~/OpenSceneGraph && \
-cp -a $OSG_PATH/build/lib externals/OpenSceneGraph/v10/ && \
-cp -a $OSG_PATH/build/include externals/OpenSceneGraph/v10/build && \
-cp -a $OSG_PATH/include externals/OpenSceneGraph/v10/ && \
-mkdir build && \
-cd build && \
-cmake ../ -DUSE_OSG=true && \
-make -j4
-
-ENV DISPLAY :1.0
-ENV LENGTH 20
-ENV RESOLUTION 320x240
-ENV FRAMERATE 20
+ENV DISPLAY=:1.0
+ENV LENGTH=20
+ENV RESOLUTION=480x270
+ENV FRAMERATE=20
+ENV VIDEO_FORMAT=gif
 COPY ./run.sh ~/
 RUN ["chmod", "+x", "~/run.sh"]
 ENTRYPOINT ["~/run.sh"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A tool which uses the [esmini OpenSCENARIO player](http://github.com/esmini/esmi
 
 This container creates an Xvfb virtual display, executes Esmini which renders to the virtual display and uses avconv to record from the virtual display to a gif
 
-Render and recording is done at 320x240
+Render and recording is done at 480x270 as default
 
 ## Getting Started
 
@@ -26,24 +26,24 @@ In order to run this container you'll need docker installed.
 * `SCENARIO` - The xosc location relative to the scenarios volume
 * `FRAMERATE` - The framerate to record at (default 20)
 * `RESOLUTION` - The target resolution (default 320x240)
+* `VIDEO_FORMAT` - Video file format extension (default gif, see [ffmpeg](https://ffmpeg.org/ffmpeg-formats.html) for supported formats)
 
 #### Sample Usage
 
-docker run -v ~/esmini/scenarios:/scenarios -e SCENARIO=M804/M4.xosc -e LENGTH=20 matthewcoylecpc/esmini-visualiser
+docker run -v ~/esmini/resources:/scenarios -e SCENARIO=xosc/cut-in.xosc -e LENGTH=20 -e VIDEO_FORMAT=mp4 matthewcoylecpc/esmini-visualiser
 
 This will do the following:
-* Execute the scenario ~/esmini/scenarios/M804/M4.xosc
-* Record a 20 second gif
-* Output to ~/esmini/scenarios/M804/M4.gif
-
+* Execute the scenario ~/esmini/resources/xosc/cut-in.xosc
+* Record a 20 second mpeg 4 video
+* Output ~/esmini/resources/cut-in.mp4 and ~/esmini/resources/cut-in.dat
 
 #### Volumes
 
-* `/scenarios/` - The base directory used to pass in scenarios
+* `/scenarios/` - The directory to pass in scenarios from and deliver output to
 
 #### Useful File Locations
 
-* `/root/esmini/build/EnvironmentSimulator/EgoSimulator/EgoSimulator` - Esmini executable
+* `/root/esmini/bin/esmini` - esmini executable
   
 * `~/run.sh` - Execution script
 
@@ -58,4 +58,4 @@ This will do the following:
 
 ## Acknowledgments
 
-* Thanks to Emil Knabe for development of Esmini including assisting the development of this container
+* Thanks to Emil Knabe for development of [esmini](https://github.com/esmini/esmini) including assisting the development of this container

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,11 @@
 
 Xvfb :1 -screen 0 ${RESOLUTION}x16 &> xvfb.log  &
 
-cd /root/esmini/build/EnvironmentSimulator/EgoSimulator/
-target=$(echo $SCENARIO | sed 's/\(.*\).xosc/\1\.gif/')
-timeout $LENGTH ./EgoSimulator --window 0 0 ${RESOLUTION//x/ } --osc "/scenarios/${SCENARIO}" --ext_control off &
-avconv -f x11grab -s $RESOLUTION -r $FRAMERATE -t $LENGTH -y -i :1.0 "/scenarios/${target}"
+cd ~/esmini
+
+# GIF animation format is default. Can be changed into anything supported by ffmpeg, e.g. VIDEO_FORMAT=mp4
+target=`sed "s/\(.*\).xosc/\1\.${VIDEO_FORMAT}/" <<< $(basename $SCENARIO)`
+
+# Video and .dat file will end up in the appointed scenarios folder
+timeout $LENGTH ./bin/esmini --window 0 0 ${RESOLUTION//x/ } --osc "/scenarios/${SCENARIO}" --record /scenarios/`sed -e 's|.xosc|.dat|g' <<< $(basename ${SCENARIO})` --disable_controllers --aa_mode 0 --info_text off & 
+ffmpeg -f x11grab -s $RESOLUTION -r $FRAMERATE -t $LENGTH -y -i :1.0 "/scenarios/${target}"


### PR DESCRIPTION
- Ubuntu 18.04 (instead of 16.04)
- Fetch latest esmini release (instead of building)
- Remove overlay info text (option in run.sh)
- Option to specify video format  (GIF is still default)
- Create a .dat file for later replay using with esmini/replayer